### PR TITLE
Outdated public key for nvidia repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ FROM zekunli/zekun-keras-gpu
 
 WORKDIR = /map-kurator
 
+
+RUN rm /etc/apt/sources.list.d/cuda.list && rm /etc/apt/sources.list.d/nvidia-ml.list
+RUN apt install -y wget
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb
+RUN dpkg -i cuda-keyring_1.0-1_all.deb
+
 # Install GDAL for Rasterio
 RUN add-apt-repository -y ppa:ubuntugis/ppa \
  && apt-get update -y \


### PR DESCRIPTION
This fix to the Docker build script hopefully addresses this issue:

https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771